### PR TITLE
Loosen up the condition for FQDN and hostname matching

### DIFF
--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -28,7 +28,7 @@ end
 node['gluster']['server']['volumes'].each do |volume_name, volume_values|
   bricks = []
   # If the node is configured as a peer for the volume, create directories to use as bricks
-  if volume_values['peers'].include?(node['fqdn']) || volume_values['peers'].include?(node['hostname'])
+  if volume_values['peers'].find{|peer| peer =~ /#{node['fqdn']}/} || volume_values['peers'].find{|peer| peer =~ /#{node['hostname']}/}
     # Use either configured LVM volumes or default LVM volumes
     # Configure the LV's per gluster volume
     # Each LV is one brick
@@ -67,10 +67,10 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
   end
 
   # Only continue if the node is the first peer in the array
-  if volume_values['peers'].first == node['fqdn'] || volume_values['peers'].first == node['hostname']
+  if volume_values['peers'].first =~ /#{node['fqdn']}/ || volume_values['peers'].first =~ /#{node['hostname']}/
     # Configure the trusted pool if needed
     volume_values['peers'].each do |peer|
-      next if peer == node['fqdn'] || peer == node['hostname']
+      next if peer =~ /#{node['fqdn']}/ || peer =~ /#{node['hostname']}/
       execute "gluster peer probe #{peer}" do
         action :run
         not_if "egrep '^hostname.+=#{peer}$' /var/lib/glusterd/peers/*"


### PR DESCRIPTION
With this, if a peer changes its FQDN or hostname before running the GlusterFS cookbook (eg. `host -> host.local`), the setup will still run correctly.

Alternatively, the `node['fqdn']` and `node['hostname']` variables should be update mid-run. This is harder than it seems, because Ohai sets these variables compile time, and they're tricky to modify. The `server-setup` recipe uses a lot of Ruby, which is interpreted at compile time, and lazy loading the automatic variables is tricky.

Doing this, is the next best thing and it's useful if you're doing local host discovery with `Avahi`. During the provisioning process, a cookbook sets up the `avahi-daemon`, and configures the FQDN to`<host>.local`, and finally GlusterFS is set up with this cookbook.